### PR TITLE
ci: use `tac` to image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,4 +140,4 @@ jobs:
       - name: Push To GHCR
         run: |
           buildah manifest inspect localhost/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          echo "${{ steps.meta.outputs.tags }}" | xargs -I{} --max-args=1 buildah manifest push --creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} --all localhost/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} docker://{}
+          tac <<< '${{ steps.meta.outputs.tags }}' | xargs -I{} --max-args=1 buildah manifest push --creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} --all localhost/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} docker://{}


### PR DESCRIPTION
後にpushされた方が優先度が高くなるので、タグを逆順にする
