### PR TITLE
ci(build): add pattern to download linux-musl artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: artifact
+          pattern: '*-unknown-linux-musl'
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Adds the `pattern: '*-unknown-linux-musl'` to the `actions/download-artifact` step in the GitHub Actions workflow. This ensures that only the Linux-musl artifacts are downloaded, which is required for the subsequent Docker image build step.