### PR TITLE
revert: "build: enable trim-paths feature to remove path information from binary"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["trim-paths"]
-
 [package]
 name = "pow-summon-discordbot"
 version = "1.1.21"
@@ -32,4 +30,3 @@ pedantic = "warn"
 strip = "symbols"
 lto = "fat"
 codegen-units = 1
-trim-paths = "all"


### PR DESCRIPTION
Reverts eoeo-org/pow-summon-discordbot#255

Renovateがstableで動くためコマンドが実行できなくて詰む。